### PR TITLE
Add availability to use custom filters on inventory request

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,12 @@
+package steam
+
+// Filter get InventoryItem and return true if item meet its condition
+// false otherwise
+type Filter func(InventoryItem) bool
+
+// IsTradable return Filter for item.Tradable option
+func IsTradable(st bool) Filter {
+	return func(item InventoryItem) bool {
+		return item.Tradable == st
+	}
+}

--- a/filters.go
+++ b/filters.go
@@ -2,11 +2,11 @@ package steam
 
 // Filter get InventoryItem and return true if item meet its condition
 // false otherwise
-type Filter func(InventoryItem) bool
+type Filter func(*InventoryItem) bool
 
 // IsTradable return Filter for item.Tradable option
 func IsTradable(st bool) Filter {
-	return func(item InventoryItem) bool {
+	return func(item *InventoryItem) bool {
 		return item.Tradable == st
 	}
 }

--- a/filters.go
+++ b/filters.go
@@ -10,3 +10,16 @@ func IsTradable(st bool) Filter {
 		return item.Tradable == st
 	}
 }
+
+// IsSouvenir filters souvenir items
+func IsSouvenir(st bool) Filter {
+	return func(item *InventoryItem) bool {
+		for _, tag := range item.Tags {
+			if tag.Category == "Quality" && tag.InternalName == "tournament" {
+				return st == true
+			}
+		}
+
+		return st == false
+	}
+}

--- a/inventory.go
+++ b/inventory.go
@@ -216,14 +216,18 @@ func (session *Session) fetchInventory(
 }
 
 func (session *Session) GetInventory(sid SteamID, appID, contextID uint64, tradableOnly bool) ([]InventoryItem, error) {
-	items := []InventoryItem{}
-	startAssetID := uint64(0)
-
 	filters := []Filter{}
 
 	if tradableOnly {
 		filters = append(filters, IsTradable(tradableOnly))
 	}
+
+	return session.GetFilterableInventory(sid, appID, contextID, filters)
+}
+
+func (session *Session) GetFilterableInventory(sid SteamID, appID, contextID uint64, filters []Filter) ([]InventoryItem, error) {
+	items := []InventoryItem{}
+	startAssetID := uint64(0)
 
 	for {
 		hasMore, lastAssetID, err := session.fetchInventory(sid, appID, contextID, startAssetID, &filters, &items)

--- a/inventory.go
+++ b/inventory.go
@@ -188,7 +188,7 @@ func (session *Session) fetchInventory(
 
 		st := true
 		for _, filter := range *filters {
-			if !filter(item) {
+			if !filter(&item) {
 				st = false
 
 				break

--- a/inventory.go
+++ b/inventory.go
@@ -14,27 +14,35 @@ const (
 	InventoryEndpoint = "http://steamcommunity.com/inventory/%d/%d/%d?"
 )
 
+type ItemTag struct {
+	Category              string `json:"category"`
+	InternalName          string `json:"internal_name"`
+	LocalizedCategoryName string `json:"localized_category_name"`
+	LocalizedTagName      string `json:"localized_tag_name"`
+}
+
 // Due to the JSON being string, etc... we cannot re-use EconItem
 // Also, "assetid" is included as "id" not as assetid.
 type InventoryItem struct {
-	AppID          uint64 `json:"appid"`
-	ContextID      uint64 `json:"contextid"`
-	AssetID        uint64 `json:"assetid"`
-	ClassID        uint64 `json:"classid"`
-	InstanceID     uint64 `json:"instanceid"`
-	Amount         uint64 `json:"amount"`
-	Tradable       bool   `json:"tradable"`
-	Currency       int    `json:"currency"`
-	IconURL        string `json:"standard"`
-	IconURLLarge   string `json:"large"`
-	Name           string `json:"text"`
-	NameColor      string `json:"color"`
-	MarketName     string `json:"market_name"`
-	MarketHashName string `json:"market_hash"`
-	Commodity      bool   `json:"commodity"`
-	Type           string `json:"type"`
-	Marketable     bool   `json:"marketable"`
-	Restrictions   int    `json:"restrictions"`
+	AppID          uint64    `json:"appid"`
+	ContextID      uint64    `json:"contextid"`
+	AssetID        uint64    `json:"assetid"`
+	ClassID        uint64    `json:"classid"`
+	InstanceID     uint64    `json:"instanceid"`
+	Amount         uint64    `json:"amount"`
+	Tradable       bool      `json:"tradable"`
+	Currency       int       `json:"currency"`
+	IconURL        string    `json:"standard"`
+	IconURLLarge   string    `json:"large"`
+	Name           string    `json:"text"`
+	NameColor      string    `json:"color"`
+	MarketName     string    `json:"market_name"`
+	MarketHashName string    `json:"market_hash"`
+	Commodity      bool      `json:"commodity"`
+	Type           string    `json:"type"`
+	Marketable     bool      `json:"marketable"`
+	Restrictions   int       `json:"restrictions"`
+	Tags           []ItemTag `json:"tags"`
 }
 
 type InventoryContext struct {
@@ -58,8 +66,9 @@ var inventoryContextRegexp = regexp.MustCompile("var g_rgAppContextData = (.*?);
 
 func (session *Session) fetchInventory(
 	sid SteamID,
-	appID, contextID uint64,
-	tradableOnly bool, startAssetID uint64, items *[]InventoryItem,
+	appID, contextID, startAssetID uint64,
+	filters *[]Filter,
+	items *[]InventoryItem,
 ) (hasMore bool, lastAssetID uint64, err error) {
 	params := url.Values{
 		"l": {session.language},
@@ -110,6 +119,7 @@ func (session *Session) fetchInventory(
 		Commodity                 int                `json:"commodity"`
 		MarketTradableRestriction int                `json:"market_tradable_restriction"`
 		Marketable                int                `json:"marketable"`
+		Tags                      []ItemTag          `json:"tags"`
 	}
 
 	type Response struct {
@@ -126,6 +136,8 @@ func (session *Session) fetchInventory(
 	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return false, 0, err
 	}
+
+	resp.Body.Close()
 
 	if response.Success == 0 {
 		if len(response.ErrorMsg) != 0 {
@@ -151,10 +163,6 @@ func (session *Session) fetchInventory(
 	for _, asset := range response.Assets {
 		key := fmt.Sprintf("%d_%d", asset.ClassID, asset.InstanceID)
 		desc := &response.Descriptions[descriptions[key]]
-		tradable := desc.Tradable != 0
-		if tradableOnly && !tradable {
-			continue
-		}
 
 		item := InventoryItem{
 			AppID:          asset.AppID,
@@ -163,7 +171,7 @@ func (session *Session) fetchInventory(
 			ClassID:        asset.ClassID,
 			InstanceID:     asset.InstanceID,
 			Amount:         asset.Amount,
-			Tradable:       tradable,
+			Tradable:       desc.Tradable != 0,
 			Currency:       desc.Currency,
 			IconURL:        desc.IconURL,
 			IconURLLarge:   desc.IconURLLarge,
@@ -175,6 +183,20 @@ func (session *Session) fetchInventory(
 			Type:           desc.Type,
 			Marketable:     desc.Marketable != 0,
 			Restrictions:   desc.MarketTradableRestriction,
+			Tags:           desc.Tags,
+		}
+
+		st := true
+		for _, filter := range *filters {
+			if !filter(item) {
+				st = false
+
+				break
+			}
+		}
+
+		if !st {
+			continue
 		}
 
 		*items = append(*items, item)
@@ -197,8 +219,14 @@ func (session *Session) GetInventory(sid SteamID, appID, contextID uint64, trada
 	items := []InventoryItem{}
 	startAssetID := uint64(0)
 
+	filters := []Filter{}
+
+	if tradableOnly {
+		filters = append(filters, IsTradable(tradableOnly))
+	}
+
 	for {
-		hasMore, lastAssetID, err := session.fetchInventory(sid, appID, contextID, tradableOnly, startAssetID, &items)
+		hasMore, lastAssetID, err := session.fetchInventory(sid, appID, contextID, startAssetID, &filters, &items)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This time, I tried to keep backward compatibility, so `GetInventory` method params wasn't changed at all. New method `GetFilterableInventory` added.

Also, tags were added, and request body closing was fixed.